### PR TITLE
sh: > nul is unnecessary

### DIFF
--- a/one-click-root.sh
+++ b/one-click-root.sh
@@ -21,25 +21,25 @@ read start
 #clear
 echo [*] copying dirtycow to /data/local/tmp/dirtycow
 adb push pushed/dirtycow /data/local/tmp/dirtycow
-sleep 10 > nul
+sleep 10
 echo [*] copying recowvery-app_process32 to /data/local/tmp/recowvery-app_process32
 adb push pushed/recowvery-app_process32 /data/local/tmp/recowvery-app_process32
-sleep 10 > nul
+sleep 10
 echo [*] copying frp.bin to /data/local/tmp/unlock
 adb push pushed/frp.bin /data/local/tmp/unlock
-sleep 10 > nul
+sleep 10
 echo [*] copying busybox to /data/local/tmp/busybox
 adb push pushed/busybox /data/local/tmp/busybox
-sleep 10 > nul
+sleep 10
 echo [*] copying cp_comands.txt to /data/local/tmp/cp_comands.txt
 adb push pushed/cp_comands.txt /data/local/tmp/cp_comands.txt
-sleep 10 > nul
+sleep 10
 echo [*] copying dd_comands.txt to /data/local/tmp/dd_comands.txt
 adb push pushed/dd_comands.txt /data/local/tmp/dd_comands.txt
-sleep 10 > nul
+sleep 10
 echo [*] changing permissions on copied files
 adb shell chmod 0777 /data/local/tmp/*
-sleep 10 > nul
+sleep 10
 #clear
 echo --------------------------------------------------------------------------------------------
 echo [*] DONE PUSHING FILES TO PHONE. NOW WE ARE GOING TO TEMP WRITE OVER THE APP_PROCESS
@@ -53,7 +53,7 @@ echo ---------------------------------------------------------------------------
 echo --------------------------------------------------------------------------------------------
 echo [*]WAITING 60 SECONDS FOR ROOT SHELL TO SPAWN
 echo [*] WHILE APP_PROCESS IS REPLACED PHONE WILL APPEAR TO BE UNRESPONSIVE BUT SHELL IS WORKING
-sleep 60 > nul
+sleep 60
 echo --------------------------------------------------------------------------------------------
 echo [*] OPENING A ROOT SHELL ON THE NEWLY CREATED SYSTEM_SERVER
 echo [*] MAKING A DIRECTORY ON PHONE TO COPY FRP PARTION TO 
@@ -65,10 +65,10 @@ adb shell "/data/local/tmp/busybox nc localhost 11112 < /data/local/tmp/cp_coman
 echo "[*] COPY UNLOCK.IMG OVER TOP OF COPIED FRP IN /data/local/test NOT AS ROOT WITH DIRTYCOW"
 echo [*]
 adb shell /data/local/tmp/dirtycow /data/local/test/frp /data/local/tmp/unlock
-sleep 5 > nul
+sleep 5
 #clear
 echo [*] WAITING 5 SECONDS BEFORE WRITING FRP TO EMMC
-sleep 5 > nul
+sleep 5
 echo "[*] DD COPY THE NEW (UNLOCK.IMG) FROM /data/local/test/frp TO PARTITION mmcblk0p17"
 adb shell "/data/local/tmp/busybox nc localhost 11112 < /data/local/tmp/dd_comands.txt"
 echo --------------------------------------------------------------------------------------------


### PR DESCRIPTION
In the sh script you have a lot of "sleep x > nul" commands which will create a blank file called "nul" in the current directory. If you want to discard output, you can use "> /dev/null" instead, but it is unnecessary here since the sleep command doesn't have any output.